### PR TITLE
Add CTO takeover: full-page flip + gradient banner

### DIFF
--- a/frontend-v3/index.html
+++ b/frontend-v3/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="flipped">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -308,6 +308,58 @@ body {
   .result-labels span { border-right: none; border-bottom: 1px solid var(--border); }
   .result-labels span:last-child { border-bottom: none; }
 }
+
+/* === CTO TAKEOVER === */
+html.flipped {
+  transform: rotate(180deg);
+  transform-origin: center center;
+}
+
+#cto-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 99999;
+  transform: rotate(180deg);
+  transform-origin: center center;
+  background: linear-gradient(90deg, #7b2ff7 0%, #f107a3 50%, #ff6a00 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 28px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  gap: 16px;
+  box-shadow: 0 -4px 32px rgba(123, 47, 247, 0.5);
+}
+
+#cto-banner span {
+  font-size: 1.1rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  flex: 1;
+  text-align: center;
+}
+
+#cto-restore-btn {
+  background: rgba(255,255,255,0.2);
+  border: 2px solid rgba(255,255,255,0.6);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 7px 18px;
+  border-radius: 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+#cto-restore-btn:hover {
+  background: rgba(255,255,255,0.35);
+}
 </style>
 </head>
 <body>
@@ -513,5 +565,11 @@ document.addEventListener('keydown', e => {
   if (e.key === 'Escape') imageModal.style.display = 'none';
 });
 </script>
+
+<!-- CTO TAKEOVER BANNER -->
+<div id="cto-banner">
+  <span>Your CTO has arrived. The old ways are over.</span>
+  <button id="cto-restore-btn" onclick="document.documentElement.classList.remove('flipped');document.getElementById('cto-banner').style.display='none'">Restore Order</button>
+</div>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="flipped">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -513,6 +513,58 @@ body {
   .pair-images img { width: 100%; height: 50%; }
   .pair-labels { flex-direction: column; }
   .pair-labels span:first-child { border-right: none; border-bottom: 1px solid var(--border); }
+}
+
+/* === CTO TAKEOVER === */
+html.flipped {
+  transform: rotate(180deg);
+  transform-origin: center center;
+}
+
+#cto-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 99999;
+  transform: rotate(180deg);
+  transform-origin: center center;
+  background: linear-gradient(90deg, #7b2ff7 0%, #f107a3 50%, #ff6a00 100%);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 28px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  gap: 16px;
+  box-shadow: 0 -4px 32px rgba(123, 47, 247, 0.5);
+}
+
+#cto-banner span {
+  font-size: 1.1rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  flex: 1;
+  text-align: center;
+}
+
+#cto-restore-btn {
+  background: rgba(255,255,255,0.2);
+  border: 2px solid rgba(255,255,255,0.6);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 7px 18px;
+  border-radius: 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+#cto-restore-btn:hover {
+  background: rgba(255,255,255,0.35);
 }
 </style>
 </head>
@@ -1078,5 +1130,11 @@ function closeModal() {
 
 imageModal.addEventListener('click', closeModal);
 </script>
+
+<!-- CTO TAKEOVER BANNER -->
+<div id="cto-banner">
+  <span>Your CTO has arrived. The old ways are over.</span>
+  <button id="cto-restore-btn" onclick="document.documentElement.classList.remove('flipped');document.getElementById('cto-banner').style.display='none'">Restore Order</button>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Flips the entire page 180° via `transform: rotate(180deg)` on `html.flipped` (set on page load)
- Adds a `position: fixed` banner counter-rotated 180° so it reads correctly at the top of the viewport
- Banner text: *\"Your CTO has arrived. The old ways are over.\"*
- Bold gradient background: purple (#7b2ff7) → pink (#f107a3) → orange (#ff6a00)
- **Restore Order** button removes the `flipped` class and hides the banner — pure CSS transforms, zero JS animation libraries
- Applied to both `frontend/index.html` and `frontend-v3/index.html`

## Test plan
- [ ] Open either frontend — page should appear upside-down on load
- [ ] Banner should be readable at the top with gradient background
- [ ] Click "Restore Order" — page flips right-side up, banner disappears
🤖 Generated with [Claude Code](https://claude.com/claude-code)