### PR TITLE
Frontend: animated skeleton screens replacing spinners

### DIFF
--- a/frontend-v3/index.html
+++ b/frontend-v3/index.html
@@ -106,45 +106,124 @@ body {
   border-radius: 14px;
 }
 
-/* Loading state */
-.loading-view {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 48px 16px;
-  max-width: 600px;
-  margin: 0 auto;
+/* ── Skeleton screens ── */
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
 }
-.loading-view .preview-img {
-  width: 256px;
-  height: 256px;
-  object-fit: contain;
-  border-radius: var(--radius);
+
+.skel {
+  background: var(--surface2);
+  border-radius: 6px;
+  animation: pulse 1.6s ease-in-out infinite;
+}
+
+/* Showcase skeleton cards */
+.skel-card {
+  width: 180px;
+  flex-shrink: 0;
+  background: var(--surface);
   border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.skel-card .skel-img {
+  width: 100%;
+  aspect-ratio: 1;
+  background: var(--surface2);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+.skel-card .skel-line {
+  margin: 10px auto 12px;
+  width: 55%;
+  height: 10px;
+  border-radius: 5px;
+  background: var(--surface2);
+  animation: pulse 1.6s ease-in-out infinite;
+}
+/* stagger each card's pulse */
+.skel-card:nth-child(1) .skel-img,
+.skel-card:nth-child(1) .skel-line { animation-delay: 0s; }
+.skel-card:nth-child(2) .skel-img,
+.skel-card:nth-child(2) .skel-line { animation-delay: 0.15s; }
+.skel-card:nth-child(3) .skel-img,
+.skel-card:nth-child(3) .skel-line { animation-delay: 0.3s; }
+.skel-card:nth-child(4) .skel-img,
+.skel-card:nth-child(4) .skel-line { animation-delay: 0.45s; }
+.skel-card:nth-child(5) .skel-img,
+.skel-card:nth-child(5) .skel-line { animation-delay: 0.6s; }
+
+/* Result skeleton (loading-view replacement) */
+.skel-result-wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 20px 16px 40px;
+}
+.skel-back-btn {
+  width: 148px;
+  height: 34px;
+  border-radius: 20px;
+  margin-bottom: 20px;
+  animation-delay: 0s;
+}
+.skel-result-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.skel-labels-row {
+  display: flex;
+  background: var(--surface2);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 0;
+  gap: 2px;
+}
+.skel-labels-row .skel {
+  flex: 1;
+  height: 11px;
+  margin: 0 28px;
+  animation-delay: 0.1s;
+}
+.skel-images-row {
+  display: flex;
+  gap: 2px;
   background: #000;
-  margin-bottom: 28px;
+  aspect-ratio: 3 / 1;
 }
-.spinner {
-  width: 36px; height: 36px;
-  border: 3px solid var(--border);
-  border-top-color: var(--accent);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin-bottom: 16px;
+.skel-images-row .skel {
+  flex: 1;
+  border-radius: 0;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
-.loading-view .loading-text {
-  font-size: 0.92rem;
-  color: var(--text-dim);
-  text-align: center;
+.skel-images-row .skel:nth-child(1) { animation-delay: 0s; }
+.skel-images-row .skel:nth-child(2) { animation-delay: 0.2s; }
+.skel-images-row .skel:nth-child(3) { animation-delay: 0.4s; }
+/* real preview image lives inside the first image slot */
+.skel-preview-slot {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #000;
 }
-.loading-view .loading-sub {
-  font-size: 0.75rem;
-  color: var(--text-dim);
-  opacity: 0.5;
-  margin-top: 6px;
+.skel-preview-slot img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
+.skel-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  flex-wrap: wrap;
+}
+.skel-badge  { width: 72px;  height: 28px; border-radius: 14px; animation-delay: 0.05s; }
+.skel-stat   { width: 110px; height: 13px; animation-delay: 0.15s; }
+.skel-stat2  { width: 80px;  height: 13px; animation-delay: 0.25s; }
+.skel-match  { width: 74px;  height: 24px; border-radius: 14px; margin-left: auto; animation-delay: 0.35s; }
+.skel-prompt-block   { margin: 0 20px 14px; height: 54px;  border-radius: 8px; animation-delay: 0.1s; }
+.skel-reasoning-block{ margin: 0 20px 16px; height: 76px;  border-radius: 8px; animation-delay: 0.2s; }
 
 /* Result view */
 .result-view {
@@ -289,24 +368,29 @@ body {
   border-radius: 8px;
 }
 
-/* Center loading */
+/* Center loading — used for error states only */
 .center-loading {
   text-align: center;
   padding: 80px 20px;
   color: var(--text-dim);
   font-size: 0.9rem;
 }
-.center-loading .spinner { margin: 0 auto 16px; }
 
 /* Responsive */
 @media (max-width: 700px) {
   .showcase { gap: 8px; }
   .showcase-card { width: 140px; }
+  .skel-card { width: 140px; }
   .result-images { flex-direction: column; aspect-ratio: 1 / 3; }
   .result-images img { width: 100%; height: 33.333%; }
   .result-labels { flex-direction: column; }
   .result-labels span { border-right: none; border-bottom: 1px solid var(--border); }
   .result-labels span:last-child { border-bottom: none; }
+  .skel-images-row { flex-direction: column; aspect-ratio: 1 / 3; }
+  .skel-images-row .skel,
+  .skel-images-row .skel-preview-slot { flex: 1; width: 100%; }
+  .skel-labels-row { flex-direction: column; gap: 8px; padding: 12px 0; }
+  .skel-labels-row .skel { margin: 0 20px; }
 }
 </style>
 </head>
@@ -316,17 +400,41 @@ body {
 <!-- Selection View -->
 <div id="selectionView">
   <div class="showcase" id="showcase">
-    <div class="center-loading"><div class="spinner"></div>Loading charts&hellip;</div>
+    <div class="skel-card"><div class="skel-img"></div><div class="skel-line"></div></div>
+    <div class="skel-card"><div class="skel-img"></div><div class="skel-line"></div></div>
+    <div class="skel-card"><div class="skel-img"></div><div class="skel-line"></div></div>
+    <div class="skel-card"><div class="skel-img"></div><div class="skel-line"></div></div>
+    <div class="skel-card"><div class="skel-img"></div><div class="skel-line"></div></div>
   </div>
 </div>
 
-<!-- Loading View -->
+<!-- Loading View — skeleton mimicking result card layout -->
 <div id="loadingView" style="display:none">
-  <div class="loading-view">
-    <img class="preview-img" id="loadingPreview" alt="Selected chart">
-    <div class="spinner"></div>
-    <div class="loading-text">Running diffusion inference&hellip;</div>
-    <div class="loading-sub">This takes 30-60 seconds</div>
+  <div class="skel-result-wrap">
+    <div class="skel skel-back-btn"></div>
+    <div class="skel-result-card">
+      <div class="skel-labels-row">
+        <div class="skel"></div>
+        <div class="skel"></div>
+        <div class="skel"></div>
+      </div>
+      <div class="skel-images-row">
+        <!-- first slot: real selected chart; others: grey skeletons -->
+        <div class="skel-preview-slot">
+          <img id="loadingPreview" alt="Selected chart">
+        </div>
+        <div class="skel"></div>
+        <div class="skel"></div>
+      </div>
+      <div class="skel-meta-row">
+        <div class="skel skel-badge"></div>
+        <div class="skel skel-stat"></div>
+        <div class="skel skel-stat2"></div>
+        <div class="skel skel-match"></div>
+      </div>
+      <div class="skel skel-prompt-block"></div>
+      <div class="skel skel-reasoning-block"></div>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- **Showcase grid**: 5 skeleton cards pulse while `/api/showcase` loads, each matching the real `.showcase-card` shape (square chart image area + `#id` pill)
- **Inference loading**: full result-card skeleton shown while diffusion runs — labels row, 3-panel image strip (real selected chart in slot 1, two grey blocks for the generated/target slots), meta row with badge/confidence/match placeholders, prompt block, reasoning block
- Staggered `animation-delay` (150ms per card / 200ms per image panel) for a ripple effect
- Pure CSS `@keyframes pulse` (opacity 1→0.3→1, 1.6s ease-in-out) — zero JS, zero deps

## Test plan
- [ ] Load page: 5 grey pulsing cards appear before showcase data arrives
- [ ] Click a chart card: result skeleton appears immediately with the selected chart in the first image slot
- [ ] Verify skeleton collapses cleanly when real result renders
- [ ] Check mobile layout (< 700px): skeleton panels stack vertically