### PR TITLE
Implement Binance-ready automated trading bot runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,116 @@ bash train/run_training_gpu.sh
 python -m bot.backtest --csv data/btc_usdt_4h.csv --checkpoint checkpoints/ --output outputs/backtest --max-samples 250
 ```
 
+### Run the automated bot
+
+Safe default is paper trading. The live execution path exists, but it is opt-in and requires explicit environment configuration.
+
+```bash
+export VIBETRADER_MODE=paper
+export VIBETRADER_CHECKPOINT=checkpoints
+python -m bot.run_bot --once
+```
+
+Run continuously:
+
+```bash
+python -m bot.run_bot
+```
+
+Control the bot manually:
+
+```bash
+python -m bot.run_bot --control pause
+python -m bot.run_bot --control resume
+python -m bot.run_bot --control kill
+python -m bot.run_bot --control clear-kill
+python -m bot.run_bot --control status
+```
+
+### Binance execution modes
+
+The bot supports three execution modes through `VIBETRADER_MODE`:
+
+- `paper`: default, fully simulated fills and balances
+- `binance_testnet`: CCXT Binance sandbox market orders, still safer than live
+- `binance_live`: real Binance spot market orders, only when explicitly configured
+
+Recommended startup:
+
+```bash
+export BINANCE_API_KEY=...
+export BINANCE_SECRET=...
+export BINANCE_TESTNET=true
+export VIBETRADER_MODE=binance_testnet
+export VIBETRADER_DRY_RUN=false
+python -m bot.run_bot --once
+```
+
+Live mode is intentionally not the default:
+
+```bash
+export BINANCE_API_KEY=...
+export BINANCE_SECRET=...
+export BINANCE_TESTNET=false
+export VIBETRADER_MODE=binance_live
+export VIBETRADER_DRY_RUN=false
+python -m bot.run_bot --once
+```
+
+### Trading runtime architecture
+
+The automated bot now implements:
+
+- machine-safe signal contracts in `bot/contracts.py`
+- market ingestion via CCXT + RSI/MACD enrichment in `bot/market.py`
+- diffusion-model inference wrapped into a deterministic signal schema in `bot/model_runtime.py`
+- a separate risk engine with confidence gating, sizing, drawdown limits, loss streak limits, and shorting controls in `bot/risk_engine.py`
+- execution adapters for paper and Binance in `bot/execution.py`
+- SQLite persistence for signals, orders, fills, positions, and events in `bot/persistence.py`
+- monitoring hooks via JSONL event logs and optional W&B in `bot/monitoring.py`
+- manual pause/kill files in `runtime/control/`
+- automatic kill switch on risk breaches
+
+### Persistence and controls
+
+By default the bot stores runtime state here:
+
+- SQLite DB: `runtime/trader.db`
+- Event log: `runtime/events.jsonl`
+- Control plane files: `runtime/control/pause` and `runtime/control/kill`
+
+### Environment variables
+
+Key configuration knobs:
+
+```bash
+VIBETRADER_MODE=paper|binance_testnet|binance_live
+VIBETRADER_DRY_RUN=true|false
+VIBETRADER_CHECKPOINT=checkpoints
+VIBETRADER_SYMBOL=BTC/USDT
+VIBETRADER_TIMEFRAME=4h
+VIBETRADER_POLL_INTERVAL_SECONDS=300
+VIBETRADER_INITIAL_BALANCE_USD=10000
+VIBETRADER_MIN_CONFIDENCE=0.62
+VIBETRADER_MAX_NOTIONAL_FRACTION=0.10
+VIBETRADER_MAX_POSITION_NOTIONAL_USD=2000
+VIBETRADER_MAX_DAILY_DRAWDOWN_PCT=0.05
+VIBETRADER_MAX_TOTAL_DRAWDOWN_PCT=0.12
+VIBETRADER_MAX_CONSECUTIVE_LOSSES=4
+VIBETRADER_ALLOW_SHORT=false
+VIBETRADER_ENABLE_WANDB=false
+BINANCE_API_KEY=...
+BINANCE_SECRET=...
+BINANCE_TESTNET=true|false
+```
+
+### Notes on execution safety
+
+- The execution path assumes trading-only API keys.
+- Default operation is safe-mode paper trading.
+- If `VIBETRADER_DRY_RUN=true`, the bot routes through the paper execution adapter even if a Binance mode is selected.
+- The current Binance execution implementation is spot-market oriented. If you want isolated margin or futures behavior later, that should be added as a separate execution adapter rather than widened implicitly.
+
 ### Launch web UI
 
 ```bash

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,1 @@
+"""Trading bot package."""

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,156 @@
+"""Configuration loader for the trading bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from pathlib import Path
+
+from bot.contracts import ExecutionMode
+
+
+TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in TRUE_VALUES
+
+
+def env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    return float(value) if value is not None else default
+
+
+def env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return int(value) if value is not None else default
+
+
+@dataclass(slots=True)
+class MonitoringConfig:
+    enable_wandb: bool = False
+    wandb_project: str = "vibetrader"
+    event_log_path: str = "runtime/events.jsonl"
+
+
+@dataclass(slots=True)
+class PersistenceConfig:
+    sqlite_path: str = "runtime/trader.db"
+    control_dir: str = "runtime/control"
+
+
+@dataclass(slots=True)
+class RiskConfig:
+    min_confidence: float = 0.62
+    max_notional_fraction: float = 0.10
+    max_position_notional_usd: float = 2000.0
+    max_daily_drawdown_pct: float = 0.05
+    max_total_drawdown_pct: float = 0.12
+    max_consecutive_losses: int = 4
+    fee_bps: float = 10.0
+    slippage_bps: float = 5.0
+    stop_loss_pct: float = 0.015
+    take_profit_pct: float = 0.03
+    allow_short: bool = False
+
+
+@dataclass(slots=True)
+class MarketConfig:
+    symbol: str = "BTC/USDT"
+    timeframe: str = "4h"
+    window_size: int = 40
+    future_candles: int = 4
+    poll_interval_seconds: int = 300
+    exchange_id: str = "binance"
+
+
+@dataclass(slots=True)
+class ModelConfig:
+    checkpoint_path: str = "checkpoints"
+    device: str = "auto"
+    num_inference_steps: int = 20
+    image_guidance_scale: float = 1.5
+    guidance_scale: float = 7.0
+    signal_source: str = "pixel"
+
+
+@dataclass(slots=True)
+class BotConfig:
+    mode: ExecutionMode = "paper"
+    dry_run: bool = True
+    binance_testnet: bool = True
+    initial_balance_usd: float = 10000.0
+    market: MarketConfig = field(default_factory=MarketConfig)
+    model: ModelConfig = field(default_factory=ModelConfig)
+    risk: RiskConfig = field(default_factory=RiskConfig)
+    persistence: PersistenceConfig = field(default_factory=PersistenceConfig)
+    monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
+
+    @property
+    def is_live_mode(self) -> bool:
+        return self.mode == "binance_live"
+
+    @property
+    def safe_default_mode(self) -> bool:
+        return self.mode in {"paper", "binance_testnet"}
+
+
+def load_config() -> BotConfig:
+    mode = os.getenv("VIBETRADER_MODE", "paper").strip()
+    if mode not in {"paper", "binance_testnet", "binance_live"}:
+        raise ValueError(
+            "VIBETRADER_MODE must be one of: paper, binance_testnet, binance_live"
+        )
+
+    config = BotConfig(
+        mode=mode,  # type: ignore[arg-type]
+        dry_run=env_bool("VIBETRADER_DRY_RUN", mode != "binance_live"),
+        binance_testnet=env_bool("BINANCE_TESTNET", True),
+        initial_balance_usd=env_float("VIBETRADER_INITIAL_BALANCE_USD", 10000.0),
+        market=MarketConfig(
+            symbol=os.getenv("VIBETRADER_SYMBOL", "BTC/USDT"),
+            timeframe=os.getenv("VIBETRADER_TIMEFRAME", "4h"),
+            window_size=env_int("VIBETRADER_WINDOW_SIZE", 40),
+            future_candles=env_int("VIBETRADER_FUTURE_CANDLES", 4),
+            poll_interval_seconds=env_int("VIBETRADER_POLL_INTERVAL_SECONDS", 300),
+            exchange_id=os.getenv("VIBETRADER_EXCHANGE_ID", "binance"),
+        ),
+        model=ModelConfig(
+            checkpoint_path=os.getenv("VIBETRADER_CHECKPOINT", "checkpoints"),
+            device=os.getenv("VIBETRADER_DEVICE", "auto"),
+            num_inference_steps=env_int("VIBETRADER_INFERENCE_STEPS", 20),
+            image_guidance_scale=env_float("VIBETRADER_IMAGE_GUIDANCE", 1.5),
+            guidance_scale=env_float("VIBETRADER_GUIDANCE", 7.0),
+            signal_source=os.getenv("VIBETRADER_SIGNAL_SOURCE", "pixel"),
+        ),
+        risk=RiskConfig(
+            min_confidence=env_float("VIBETRADER_MIN_CONFIDENCE", 0.62),
+            max_notional_fraction=env_float("VIBETRADER_MAX_NOTIONAL_FRACTION", 0.10),
+            max_position_notional_usd=env_float("VIBETRADER_MAX_POSITION_NOTIONAL_USD", 2000.0),
+            max_daily_drawdown_pct=env_float("VIBETRADER_MAX_DAILY_DRAWDOWN_PCT", 0.05),
+            max_total_drawdown_pct=env_float("VIBETRADER_MAX_TOTAL_DRAWDOWN_PCT", 0.12),
+            max_consecutive_losses=env_int("VIBETRADER_MAX_CONSECUTIVE_LOSSES", 4),
+            fee_bps=env_float("VIBETRADER_FEE_BPS", 10.0),
+            slippage_bps=env_float("VIBETRADER_SLIPPAGE_BPS", 5.0),
+            stop_loss_pct=env_float("VIBETRADER_STOP_LOSS_PCT", 0.015),
+            take_profit_pct=env_float("VIBETRADER_TAKE_PROFIT_PCT", 0.03),
+            allow_short=env_bool("VIBETRADER_ALLOW_SHORT", False),
+        ),
+        persistence=PersistenceConfig(
+            sqlite_path=os.getenv("VIBETRADER_SQLITE_PATH", "runtime/trader.db"),
+            control_dir=os.getenv("VIBETRADER_CONTROL_DIR", "runtime/control"),
+        ),
+        monitoring=MonitoringConfig(
+            enable_wandb=env_bool("VIBETRADER_ENABLE_WANDB", False),
+            wandb_project=os.getenv("VIBETRADER_WANDB_PROJECT", "vibetrader"),
+            event_log_path=os.getenv("VIBETRADER_EVENT_LOG_PATH", "runtime/events.jsonl"),
+        ),
+    )
+
+    Path(config.persistence.control_dir).mkdir(parents=True, exist_ok=True)
+    Path(config.persistence.sqlite_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(config.monitoring.event_log_path).parent.mkdir(parents=True, exist_ok=True)
+    return config

--- a/bot/contracts.py
+++ b/bot/contracts.py
@@ -1,0 +1,127 @@
+"""Typed contracts for trading signals and bot state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+import uuid
+
+
+SignalAction = Literal["BUY", "SELL", "HOLD"]
+ExecutionMode = Literal["paper", "binance_testnet", "binance_live"]
+OrderSide = Literal["buy", "sell"]
+OrderIntent = Literal["open_long", "close_long", "open_short", "close_short", "hold"]
+OrderStatus = Literal["accepted", "rejected", "filled", "paper_filled", "cancelled", "error"]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+@dataclass(slots=True)
+class SignalContract:
+    """Machine-safe signal produced by the model pipeline."""
+
+    signal_id: str
+    timestamp: str
+    symbol: str
+    timeframe: str
+    action: SignalAction
+    confidence: float
+    price: float
+    prompt: str
+    source: str
+    reasons: list[str] = field(default_factory=list)
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RiskDecision:
+    approved: bool
+    intent: OrderIntent
+    side: OrderSide | None
+    quantity: float
+    notional_usd: float
+    leverage: float
+    reasons: list[str] = field(default_factory=list)
+    stop_loss_pct: float | None = None
+    take_profit_pct: float | None = None
+    reduce_only: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class OrderRecord:
+    order_id: str
+    created_at: str
+    signal_id: str
+    symbol: str
+    side: OrderSide
+    intent: OrderIntent
+    quantity: float
+    requested_price: float
+    mode: ExecutionMode
+    status: OrderStatus
+    exchange_order_id: str | None = None
+    average_fill_price: float | None = None
+    filled_quantity: float | None = None
+    fees_usd: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class FillRecord:
+    fill_id: str
+    order_id: str
+    timestamp: str
+    symbol: str
+    side: OrderSide
+    quantity: float
+    price: float
+    fees_usd: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PositionRecord:
+    symbol: str
+    updated_at: str
+    quantity: float
+    entry_price: float
+    mark_price: float
+    realized_pnl: float
+    unrealized_pnl: float
+    mode: ExecutionMode
+    status: Literal["flat", "long", "short"]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class BotEvent:
+    event_id: str
+    timestamp: str
+    level: Literal["INFO", "WARN", "ERROR", "CRITICAL"]
+    event_type: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/bot/control.py
+++ b/bot/control.py
@@ -1,0 +1,32 @@
+"""Manual pause and kill-switch controls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class ControlPlane:
+    def __init__(self, control_dir: str):
+        self.control_dir = Path(control_dir)
+        self.control_dir.mkdir(parents=True, exist_ok=True)
+        self.pause_file = self.control_dir / "pause"
+        self.kill_file = self.control_dir / "kill"
+
+    def is_paused(self) -> bool:
+        return self.pause_file.exists()
+
+    def is_killed(self) -> bool:
+        return self.kill_file.exists()
+
+    def set_paused(self, paused: bool) -> None:
+        if paused:
+            self.pause_file.touch()
+        elif self.pause_file.exists():
+            self.pause_file.unlink()
+
+    def trigger_kill(self, reason: str | None = None) -> None:
+        self.kill_file.write_text((reason or "kill switch engaged").strip() + "\n", encoding="utf-8")
+
+    def clear_kill(self) -> None:
+        if self.kill_file.exists():
+            self.kill_file.unlink()

--- a/bot/execution.py
+++ b/bot/execution.py
@@ -1,0 +1,109 @@
+"""Execution adapters for paper and Binance trading."""
+
+from __future__ import annotations
+
+import os
+
+try:
+    import ccxt
+except ImportError:  # pragma: no cover
+    ccxt = None
+
+from bot.contracts import FillRecord, OrderRecord, PositionRecord, new_id, utc_now_iso
+
+
+class BaseExecutionClient:
+    def submit_order(self, order: OrderRecord) -> tuple[OrderRecord, FillRecord]:
+        raise NotImplementedError
+
+
+class PaperExecutionClient(BaseExecutionClient):
+    def __init__(self, fee_bps: float, slippage_bps: float):
+        self.fee_bps = fee_bps
+        self.slippage_bps = slippage_bps
+
+    def submit_order(self, order: OrderRecord) -> tuple[OrderRecord, FillRecord]:
+        direction = 1 if order.side == "buy" else -1
+        slip_multiplier = 1 + (direction * self.slippage_bps / 10_000)
+        fill_price = order.requested_price * slip_multiplier
+        fees = fill_price * order.quantity * (self.fee_bps / 10_000)
+        order.status = "paper_filled"
+        order.average_fill_price = fill_price
+        order.filled_quantity = order.quantity
+        order.fees_usd = fees
+        fill = FillRecord(
+            fill_id=new_id("fill"),
+            order_id=order.order_id,
+            timestamp=utc_now_iso(),
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            price=fill_price,
+            fees_usd=fees,
+            metadata={"execution": "paper"},
+        )
+        return order, fill
+
+
+class BinanceExecutionClient(BaseExecutionClient):
+    def __init__(self, testnet: bool = True):
+        if ccxt is None:
+            raise ImportError("ccxt is required for Binance execution. Install with: pip install ccxt")
+        api_key = os.getenv("BINANCE_API_KEY")
+        secret = os.getenv("BINANCE_SECRET")
+        if not api_key or not secret:
+            raise RuntimeError("BINANCE_API_KEY and BINANCE_SECRET are required for Binance execution")
+
+        self.exchange = ccxt.binance({
+            "apiKey": api_key,
+            "secret": secret,
+            "enableRateLimit": True,
+            "options": {"defaultType": "spot"},
+        })
+        self.exchange.set_sandbox_mode(testnet)
+
+    def submit_order(self, order: OrderRecord) -> tuple[OrderRecord, FillRecord]:
+        response = self.exchange.create_order(
+            symbol=order.symbol,
+            type="market",
+            side=order.side,
+            amount=order.quantity,
+            params={},
+        )
+        filled = float(response.get("filled") or order.quantity)
+        avg_price = float(response.get("average") or response.get("price") or order.requested_price)
+        fee_cost = 0.0
+        fees = response.get("fees") or []
+        if fees:
+            fee_cost = sum(float(fee.get("cost", 0.0)) for fee in fees)
+        order.status = "filled"
+        order.exchange_order_id = str(response.get("id"))
+        order.average_fill_price = avg_price
+        order.filled_quantity = filled
+        order.fees_usd = fee_cost
+        fill = FillRecord(
+            fill_id=new_id("fill"),
+            order_id=order.order_id,
+            timestamp=utc_now_iso(),
+            symbol=order.symbol,
+            side=order.side,
+            quantity=filled,
+            price=avg_price,
+            fees_usd=fee_cost,
+            metadata={"execution": "binance", "exchange_order_id": order.exchange_order_id},
+        )
+        return order, fill
+
+
+def flat_position(symbol: str, mode: str) -> PositionRecord:
+    return PositionRecord(
+        symbol=symbol,
+        updated_at=utc_now_iso(),
+        quantity=0.0,
+        entry_price=0.0,
+        mark_price=0.0,
+        realized_pnl=0.0,
+        unrealized_pnl=0.0,
+        mode=mode,
+        status="flat",
+    )

--- a/bot/market.py
+++ b/bot/market.py
@@ -1,0 +1,65 @@
+"""Market data adapter for Binance/CCXT."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import pandas as pd
+import pandas_ta as ta
+
+try:
+    import ccxt
+except ImportError:  # pragma: no cover
+    ccxt = None
+
+
+@dataclass(slots=True)
+class MarketSnapshot:
+    candles: pd.DataFrame
+    last_price: float
+    rsi: float
+    macd: float
+
+
+class MarketDataClient:
+    def __init__(self, exchange_id: str, testnet: bool = True):
+        if ccxt is None:
+            raise ImportError("ccxt is required for market connectivity. Install with: pip install ccxt")
+
+        config: dict[str, object] = {"enableRateLimit": True}
+        api_key = os.getenv("BINANCE_API_KEY")
+        secret = os.getenv("BINANCE_SECRET")
+        if api_key and secret:
+            config["apiKey"] = api_key
+            config["secret"] = secret
+
+        exchange_cls = getattr(ccxt, exchange_id)
+        self.exchange = exchange_cls(config)
+        if exchange_id == "binance" and testnet:
+            self.exchange.set_sandbox_mode(True)
+
+    def fetch_recent_snapshot(self, symbol: str, timeframe: str, window_size: int) -> MarketSnapshot:
+        candles = self.exchange.fetch_ohlcv(symbol, timeframe, limit=window_size + 50)
+        df = pd.DataFrame(
+            candles,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
+        )
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+        df = self._add_indicators(df).tail(window_size).reset_index(drop=True)
+
+        last_row = df.iloc[-1]
+        return MarketSnapshot(
+            candles=df,
+            last_price=float(last_row["close"]),
+            rsi=float(last_row.get("rsi", 50.0)),
+            macd=float(last_row.get("MACD_12_26_9", 0.0)),
+        )
+
+    @staticmethod
+    def _add_indicators(df: pd.DataFrame) -> pd.DataFrame:
+        df = df.copy()
+        df["rsi"] = ta.rsi(df["close"], length=14)
+        macd = ta.macd(df["close"], fast=12, slow=26, signal=9)
+        df = pd.concat([df, macd], axis=1)
+        return df.dropna().reset_index(drop=True)

--- a/bot/model_runtime.py
+++ b/bot/model_runtime.py
@@ -1,0 +1,85 @@
+"""Model runtime that converts chart generation into a machine-safe signal contract."""
+
+from __future__ import annotations
+
+from bot.contracts import SignalContract, new_id, utc_now_iso
+from data.render_charts import render_candlestick
+from inference.extract_signal import extract_signal
+from inference.predict import load_pipeline, predict
+
+
+class ModelRuntime:
+    def __init__(
+        self,
+        checkpoint_path: str,
+        device: str,
+        num_inference_steps: int,
+        image_guidance_scale: float,
+        guidance_scale: float,
+    ):
+        self.pipe = load_pipeline(checkpoint_path, device=device)
+        self.num_inference_steps = num_inference_steps
+        self.image_guidance_scale = image_guidance_scale
+        self.guidance_scale = guidance_scale
+
+    def infer_signal(
+        self,
+        symbol: str,
+        timeframe: str,
+        candles,
+        future_candles: int,
+        rsi: float,
+        macd: float,
+    ) -> SignalContract:
+        total_slots = len(candles) + future_candles
+        price_low = float(candles["low"].min())
+        price_high = float(candles["high"].max())
+        prompt = (
+            f"Predict next {future_candles} candles. "
+            f"RSI={round(float(rsi), 1)}, MACD={round(float(macd), 2)}"
+        )
+        chart = render_candlestick(
+            candles,
+            draw_marker=False,
+            total_slots=total_slots,
+            price_low=price_low,
+            price_high=price_high,
+        )
+        generated = predict(
+            self.pipe,
+            chart,
+            prompt,
+            num_inference_steps=self.num_inference_steps,
+            image_guidance_scale=self.image_guidance_scale,
+            guidance_scale=self.guidance_scale,
+        )
+        extracted = extract_signal(
+            generated,
+            window_size=len(candles),
+            future_candles=future_candles,
+        )
+        last_price = float(candles.iloc[-1]["close"])
+        reasons = [
+            f"pixel_green_pct={extracted.green_pct:.3f}",
+            f"pixel_red_pct={extracted.red_pct:.3f}",
+            f"confidence={extracted.confidence:.3f}",
+        ]
+        diagnostics = {
+            "green_pct": extracted.green_pct,
+            "red_pct": extracted.red_pct,
+            "window_size": len(candles),
+            "future_candles": future_candles,
+        }
+        return SignalContract(
+            signal_id=new_id("sig"),
+            timestamp=utc_now_iso(),
+            symbol=symbol,
+            timeframe=timeframe,
+            action=extracted.action,
+            confidence=extracted.confidence,
+            price=last_price,
+            prompt=prompt,
+            source="diffusion_pixel_contract_v1",
+            reasons=reasons,
+            diagnostics=diagnostics,
+        )

--- a/bot/monitoring.py
+++ b/bot/monitoring.py
@@ -1,0 +1,41 @@
+"""Monitoring hooks for runtime events and metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from bot.contracts import BotEvent
+
+try:
+    import wandb
+    HAS_WANDB = True
+except ImportError:
+    HAS_WANDB = False
+
+
+class Monitor:
+    def __init__(self, event_log_path: str, enable_wandb: bool, wandb_project: str):
+        self.event_log_path = Path(event_log_path)
+        self.enable_wandb = enable_wandb and HAS_WANDB
+        self.wandb_project = wandb_project
+        self._wandb_started = False
+
+    def start(self, config: dict[str, Any]) -> None:
+        if self.enable_wandb and not self._wandb_started:
+            wandb.init(project=self.wandb_project, job_type="trading_bot", config=config)
+            self._wandb_started = True
+
+    def stop(self) -> None:
+        if self._wandb_started:
+            wandb.finish()
+            self._wandb_started = False
+
+    def log_event(self, event: BotEvent) -> None:
+        with self.event_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.to_dict()) + "\n")
+
+    def log_metrics(self, metrics: dict[str, Any]) -> None:
+        if self._wandb_started:
+            wandb.log(metrics)

--- a/bot/persistence.py
+++ b/bot/persistence.py
@@ -1,0 +1,221 @@
+"""SQLite persistence layer for signals, orders, fills, positions, and metrics."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from bot.contracts import BotEvent, FillRecord, OrderRecord, PositionRecord, SignalContract
+
+
+class Persistence:
+    def __init__(self, sqlite_path: str):
+        self.sqlite_path = sqlite_path
+        Path(sqlite_path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.sqlite_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS signals (
+                    signal_id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    timeframe TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    confidence REAL NOT NULL,
+                    price REAL NOT NULL,
+                    prompt TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    reasons_json TEXT NOT NULL,
+                    diagnostics_json TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS orders (
+                    order_id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    signal_id TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    intent TEXT NOT NULL,
+                    quantity REAL NOT NULL,
+                    requested_price REAL NOT NULL,
+                    mode TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    exchange_order_id TEXT,
+                    average_fill_price REAL,
+                    filled_quantity REAL,
+                    fees_usd REAL NOT NULL,
+                    metadata_json TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS fills (
+                    fill_id TEXT PRIMARY KEY,
+                    order_id TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    quantity REAL NOT NULL,
+                    price REAL NOT NULL,
+                    fees_usd REAL NOT NULL,
+                    metadata_json TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS positions (
+                    symbol TEXT PRIMARY KEY,
+                    updated_at TEXT NOT NULL,
+                    quantity REAL NOT NULL,
+                    entry_price REAL NOT NULL,
+                    mark_price REAL NOT NULL,
+                    realized_pnl REAL NOT NULL,
+                    unrealized_pnl REAL NOT NULL,
+                    mode TEXT NOT NULL,
+                    status TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS bot_events (
+                    event_id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    level TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    details_json TEXT NOT NULL
+                );
+                """
+            )
+
+    def save_signal(self, signal: SignalContract) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO signals
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    signal.signal_id,
+                    signal.timestamp,
+                    signal.symbol,
+                    signal.timeframe,
+                    signal.action,
+                    signal.confidence,
+                    signal.price,
+                    signal.prompt,
+                    signal.source,
+                    json.dumps(signal.reasons),
+                    json.dumps(signal.diagnostics),
+                ),
+            )
+
+    def save_order(self, order: OrderRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO orders
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    order.order_id,
+                    order.created_at,
+                    order.signal_id,
+                    order.symbol,
+                    order.side,
+                    order.intent,
+                    order.quantity,
+                    order.requested_price,
+                    order.mode,
+                    order.status,
+                    order.exchange_order_id,
+                    order.average_fill_price,
+                    order.filled_quantity,
+                    order.fees_usd,
+                    json.dumps(order.metadata),
+                ),
+            )
+
+    def save_fill(self, fill: FillRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO fills
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    fill.fill_id,
+                    fill.order_id,
+                    fill.timestamp,
+                    fill.symbol,
+                    fill.side,
+                    fill.quantity,
+                    fill.price,
+                    fill.fees_usd,
+                    json.dumps(fill.metadata),
+                ),
+            )
+
+    def save_position(self, position: PositionRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO positions
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    position.symbol,
+                    position.updated_at,
+                    position.quantity,
+                    position.entry_price,
+                    position.mark_price,
+                    position.realized_pnl,
+                    position.unrealized_pnl,
+                    position.mode,
+                    position.status,
+                ),
+            )
+
+    def save_event(self, event: BotEvent) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO bot_events
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.timestamp,
+                    event.level,
+                    event.event_type,
+                    event.message,
+                    json.dumps(event.details),
+                ),
+            )
+
+    def get_position(self, symbol: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM positions WHERE symbol = ?",
+                (symbol,),
+            ).fetchone()
+            return dict(row) if row else None
+
+    def list_recent_orders(self, limit: int = 20) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM orders ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def get_realized_pnl_sum(self) -> float:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(realized_pnl), 0.0) AS total FROM positions"
+            ).fetchone()
+            return float(row["total"]) if row else 0.0

--- a/bot/risk_engine.py
+++ b/bot/risk_engine.py
@@ -1,0 +1,129 @@
+"""Risk engine and automatic kill-switch logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from math import floor
+
+from bot.config import RiskConfig
+from bot.contracts import PositionRecord, RiskDecision
+
+
+@dataclass(slots=True)
+class PortfolioState:
+    cash_usd: float
+    equity_usd: float
+    start_equity_usd: float
+    daily_start_equity_usd: float
+    consecutive_losses: int
+    current_position: PositionRecord
+
+
+class RiskEngine:
+    def __init__(self, config: RiskConfig):
+        self.config = config
+
+    def evaluate(self, signal, portfolio: PortfolioState) -> RiskDecision:
+        reasons: list[str] = []
+        current_qty = portfolio.current_position.quantity
+        price = signal.price
+
+        if signal.confidence < self.config.min_confidence:
+            reasons.append(
+                f"confidence {signal.confidence:.3f} below threshold {self.config.min_confidence:.3f}"
+            )
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+
+        total_drawdown = 1.0 - (portfolio.equity_usd / max(portfolio.start_equity_usd, 1e-9))
+        daily_drawdown = 1.0 - (
+            portfolio.equity_usd / max(portfolio.daily_start_equity_usd, 1e-9)
+        )
+        if total_drawdown >= self.config.max_total_drawdown_pct:
+            reasons.append("total drawdown limit breached")
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+        if daily_drawdown >= self.config.max_daily_drawdown_pct:
+            reasons.append("daily drawdown limit breached")
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+        if portfolio.consecutive_losses >= self.config.max_consecutive_losses:
+            reasons.append("consecutive loss limit breached")
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+
+        risk_budget = min(
+            portfolio.equity_usd * self.config.max_notional_fraction,
+            self.config.max_position_notional_usd,
+        )
+        quantity = floor((risk_budget / price) * 1_000_000) / 1_000_000
+        if quantity <= 0:
+            reasons.append("computed quantity rounded to zero")
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+
+        if signal.action == "BUY":
+            if current_qty < 0:
+                return RiskDecision(
+                    True,
+                    "close_short",
+                    "buy",
+                    abs(current_qty),
+                    abs(current_qty) * price,
+                    1.0,
+                    ["closing short before changing direction"],
+                    self.config.stop_loss_pct,
+                    self.config.take_profit_pct,
+                    True,
+                )
+            if current_qty > 0:
+                reasons.append("already long")
+                return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+            return RiskDecision(
+                True,
+                "open_long",
+                "buy",
+                quantity,
+                quantity * price,
+                1.0,
+                ["long entry approved"],
+                self.config.stop_loss_pct,
+                self.config.take_profit_pct,
+                False,
+            )
+
+        if signal.action == "SELL":
+            if current_qty > 0:
+                return RiskDecision(
+                    True,
+                    "close_long",
+                    "sell",
+                    current_qty,
+                    current_qty * price,
+                    1.0,
+                    ["closing long on sell signal"],
+                    self.config.stop_loss_pct,
+                    self.config.take_profit_pct,
+                    True,
+                )
+            if self.config.allow_short:
+                if current_qty < 0:
+                    reasons.append("already short")
+                    return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+                return RiskDecision(
+                    True,
+                    "open_short",
+                    "sell",
+                    quantity,
+                    quantity * price,
+                    1.0,
+                    ["short entry approved"],
+                    self.config.stop_loss_pct,
+                    self.config.take_profit_pct,
+                    False,
+                )
+            reasons.append("shorting disabled")
+            return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+
+        reasons.append("hold signal")
+        return RiskDecision(False, "hold", None, 0.0, 0.0, 1.0, reasons)
+
+    @staticmethod
+    def utc_day_key() -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/bot/run_bot.py
+++ b/bot/run_bot.py
@@ -1,0 +1,52 @@
+"""CLI entrypoint for automated trading bot."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from bot.config import load_config
+from bot.control import ControlPlane
+from bot.runtime import TradingBot
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Automated VibeTrader bot")
+    parser.add_argument("--once", action="store_true", help="Run a single trading iteration")
+    parser.add_argument("--max-iterations", type=int, default=None, help="Limit loop iterations")
+    parser.add_argument(
+        "--control",
+        choices=["pause", "resume", "kill", "clear-kill", "status"],
+        default=None,
+        help="Operate the control plane without starting the bot",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+    control = ControlPlane(config.persistence.control_dir)
+
+    if args.control:
+        if args.control == "pause":
+            control.set_paused(True)
+        elif args.control == "resume":
+            control.set_paused(False)
+        elif args.control == "kill":
+            control.trigger_kill("manual operator kill switch")
+        elif args.control == "clear-kill":
+            control.clear_kill()
+        print(json.dumps({
+            "paused": control.is_paused(),
+            "killed": control.is_killed(),
+            "control_dir": config.persistence.control_dir,
+        }, indent=2))
+        return
+
+    bot = TradingBot(config)
+    if args.once:
+        print(json.dumps(bot.run_once(), indent=2))
+    else:
+        bot.run_loop(max_iterations=args.max_iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/bot/runtime.py
+++ b/bot/runtime.py
@@ -1,0 +1,236 @@
+"""End-to-end automated trading bot runtime."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict
+
+from bot.config import BotConfig
+from bot.contracts import BotEvent, OrderRecord, PositionRecord, new_id, utc_now_iso
+from bot.control import ControlPlane
+from bot.execution import BinanceExecutionClient, PaperExecutionClient, flat_position
+from bot.market import MarketDataClient
+from bot.model_runtime import ModelRuntime
+from bot.monitoring import Monitor
+from bot.persistence import Persistence
+from bot.risk_engine import PortfolioState, RiskEngine
+
+
+class TradingBot:
+    def __init__(self, config: BotConfig):
+        self.config = config
+        self.persistence = Persistence(config.persistence.sqlite_path)
+        self.control = ControlPlane(config.persistence.control_dir)
+        self.monitor = Monitor(
+            config.monitoring.event_log_path,
+            config.monitoring.enable_wandb,
+            config.monitoring.wandb_project,
+        )
+        self.market = MarketDataClient(
+            exchange_id=config.market.exchange_id,
+            testnet=config.binance_testnet,
+        )
+        self.model = ModelRuntime(
+            checkpoint_path=config.model.checkpoint_path,
+            device=config.model.device,
+            num_inference_steps=config.model.num_inference_steps,
+            image_guidance_scale=config.model.image_guidance_scale,
+            guidance_scale=config.model.guidance_scale,
+        )
+        self.risk = RiskEngine(config.risk)
+        self.execution = (
+            PaperExecutionClient(config.risk.fee_bps, config.risk.slippage_bps)
+            if config.mode == "paper" or config.dry_run
+            else BinanceExecutionClient(testnet=config.binance_testnet)
+        )
+        self.cash_usd = config.initial_balance_usd
+        self.start_equity_usd = config.initial_balance_usd
+        self.daily_start_equity_usd = config.initial_balance_usd
+        self.daily_key = self.risk.utc_day_key()
+        self.consecutive_losses = 0
+        self.position = self._load_or_create_position()
+
+    def _load_or_create_position(self) -> PositionRecord:
+        row = self.persistence.get_position(self.config.market.symbol)
+        if row:
+            return PositionRecord(**row)
+        position = flat_position(self.config.market.symbol, self.config.mode)
+        self.persistence.save_position(position)
+        return position
+
+    def _event(self, level: str, event_type: str, message: str, details: dict | None = None) -> None:
+        event = BotEvent(
+            event_id=new_id("evt"),
+            timestamp=utc_now_iso(),
+            level=level,  # type: ignore[arg-type]
+            event_type=event_type,
+            message=message,
+            details=details or {},
+        )
+        self.persistence.save_event(event)
+        self.monitor.log_event(event)
+
+    def _refresh_daily_baseline_if_needed(self) -> None:
+        current_day = self.risk.utc_day_key()
+        if current_day != self.daily_key:
+            self.daily_key = current_day
+            self.daily_start_equity_usd = self.current_equity(self.position.mark_price or self.position.entry_price or 0.0)
+
+    def current_equity(self, mark_price: float) -> float:
+        if self.position.quantity > 0:
+            unrealized = (mark_price - self.position.entry_price) * self.position.quantity
+        elif self.position.quantity < 0:
+            unrealized = (self.position.entry_price - mark_price) * abs(self.position.quantity)
+        else:
+            unrealized = 0.0
+        self.position.unrealized_pnl = unrealized
+        self.position.mark_price = mark_price
+        return self.cash_usd + unrealized
+
+    def _update_position_from_fill(self, fill, intent: str) -> None:
+        qty = fill.quantity
+        price = fill.price
+        fees = fill.fees_usd
+        realized_change = 0.0
+
+        if intent == "open_long":
+            self.cash_usd -= qty * price + fees
+            self.position.quantity = qty
+            self.position.entry_price = price
+        elif intent == "close_long":
+            realized_change = (price - self.position.entry_price) * self.position.quantity - fees
+            self.cash_usd += self.position.quantity * price - fees
+            self.position.realized_pnl += realized_change
+            self.position.quantity = 0.0
+            self.position.entry_price = 0.0
+        elif intent == "open_short":
+            self.cash_usd += qty * price - fees
+            self.position.quantity = -qty
+            self.position.entry_price = price
+        elif intent == "close_short":
+            realized_change = (self.position.entry_price - price) * abs(self.position.quantity) - fees
+            self.cash_usd -= abs(self.position.quantity) * price + fees
+            self.position.realized_pnl += realized_change
+            self.position.quantity = 0.0
+            self.position.entry_price = 0.0
+
+        if realized_change < 0:
+            self.consecutive_losses += 1
+        elif realized_change > 0:
+            self.consecutive_losses = 0
+
+        self.position.updated_at = utc_now_iso()
+        self.position.status = (
+            "long" if self.position.quantity > 0 else "short" if self.position.quantity < 0 else "flat"
+        )
+
+    def run_once(self) -> dict:
+        self._refresh_daily_baseline_if_needed()
+        if self.control.is_killed():
+            self._event("CRITICAL", "kill_switch", "Kill switch is active; refusing to trade")
+            raise RuntimeError("Kill switch is active")
+        if self.control.is_paused():
+            self._event("WARN", "paused", "Bot is paused; skipping iteration")
+            return {"status": "paused"}
+
+        snapshot = self.market.fetch_recent_snapshot(
+            self.config.market.symbol,
+            self.config.market.timeframe,
+            self.config.market.window_size,
+        )
+        equity = self.current_equity(snapshot.last_price)
+
+        signal = self.model.infer_signal(
+            symbol=self.config.market.symbol,
+            timeframe=self.config.market.timeframe,
+            candles=snapshot.candles,
+            future_candles=self.config.market.future_candles,
+            rsi=snapshot.rsi,
+            macd=snapshot.macd,
+        )
+        self.persistence.save_signal(signal)
+
+        portfolio = PortfolioState(
+            cash_usd=self.cash_usd,
+            equity_usd=equity,
+            start_equity_usd=self.start_equity_usd,
+            daily_start_equity_usd=self.daily_start_equity_usd,
+            consecutive_losses=self.consecutive_losses,
+            current_position=self.position,
+        )
+        decision = self.risk.evaluate(signal, portfolio)
+
+        if not decision.approved or not decision.side:
+            if any("breached" in reason for reason in decision.reasons):
+                self.control.trigger_kill("; ".join(decision.reasons))
+                self._event("CRITICAL", "risk_kill_switch", "Risk guard triggered kill switch", {
+                    "reasons": decision.reasons,
+                    "signal": signal.to_dict(),
+                })
+            else:
+                self._event("INFO", "signal_rejected", "Risk engine rejected signal", {
+                    "signal": signal.to_dict(),
+                    "decision": decision.to_dict(),
+                })
+            self.monitor.log_metrics({
+                "equity_usd": equity,
+                "signal_confidence": signal.confidence,
+                "position_qty": self.position.quantity,
+            })
+            return {"status": "rejected", "signal": signal.to_dict(), "decision": decision.to_dict()}
+
+        order = OrderRecord(
+            order_id=new_id("ord"),
+            created_at=utc_now_iso(),
+            signal_id=signal.signal_id,
+            symbol=signal.symbol,
+            side=decision.side,
+            intent=decision.intent,
+            quantity=decision.quantity,
+            requested_price=signal.price,
+            mode=self.config.mode,
+            status="accepted",
+            metadata={"risk": decision.to_dict(), "dry_run": self.config.dry_run},
+        )
+        self.persistence.save_order(order)
+
+        order, fill = self.execution.submit_order(order)
+        self.persistence.save_order(order)
+        self.persistence.save_fill(fill)
+
+        self._update_position_from_fill(fill, decision.intent)
+        self.current_equity(snapshot.last_price)
+        self.persistence.save_position(self.position)
+
+        result = {
+            "status": "executed",
+            "signal": signal.to_dict(),
+            "decision": decision.to_dict(),
+            "order": order.to_dict(),
+            "fill": fill.to_dict(),
+            "position": self.position.to_dict(),
+            "cash_usd": self.cash_usd,
+            "equity_usd": self.current_equity(snapshot.last_price),
+        }
+        self._event("INFO", "order_executed", "Order executed", result)
+        self.monitor.log_metrics({
+            "equity_usd": result["equity_usd"],
+            "cash_usd": self.cash_usd,
+            "position_qty": self.position.quantity,
+            "signal_confidence": signal.confidence,
+        })
+        return result
+
+    def run_loop(self, max_iterations: int | None = None) -> None:
+        self.monitor.start({"config": json.loads(json.dumps(asdict(self.config), default=str))})
+        self._event("INFO", "startup", "Trading bot started", {"mode": self.config.mode, "dry_run": self.config.dry_run})
+        count = 0
+        try:
+            while max_iterations is None or count < max_iterations:
+                self.run_once()
+                count += 1
+                time.sleep(self.config.market.poll_interval_seconds)
+        finally:
+            self._event("INFO", "shutdown", "Trading bot stopped", {"iterations": count})
+            self.monitor.stop()

--- a/data/fetch_ohlcv.py
+++ b/data/fetch_ohlcv.py
@@ -15,6 +15,7 @@ def fetch_ohlcv(
     timeframe: str = "4h",
     since_days: int = 730,
     exchange_id: str = "binance",
+    testnet: bool = False,
 ) -> pd.DataFrame:
     """Download OHLCV data from exchange.
 
@@ -34,6 +35,8 @@ def fetch_ohlcv(
         config["apiKey"] = api_key
         config["secret"] = secret
     exchange = getattr(ccxt, exchange_id)(config)
+    if exchange_id == "binance" and testnet:
+        exchange.set_sandbox_mode(True)
     since = exchange.milliseconds() - since_days * 24 * 60 * 60 * 1000
 
     all_candles = []
@@ -68,10 +71,11 @@ def main():
     parser.add_argument("--timeframe", default="4h")
     parser.add_argument("--days", type=int, default=730)
     parser.add_argument("--output", default="data/btc_usdt_4h.csv")
+    parser.add_argument("--testnet", action="store_true")
     args = parser.parse_args()
 
     print(f"Fetching {args.symbol} {args.timeframe} candles for {args.days} days...")
-    df = fetch_ohlcv(args.symbol, args.timeframe, args.days)
+    df = fetch_ohlcv(args.symbol, args.timeframe, args.days, testnet=args.testnet)
     print(f"Fetched {len(df)} candles")
 
     print("Computing indicators...")


### PR DESCRIPTION
## Summary
- add an end-to-end automated trading runtime around the existing diffusion signal model
- introduce typed signal, risk, execution, monitoring, persistence, and control-plane modules
- default all execution to paper/testnet-safe behavior unless explicitly configured otherwise

## Test plan
- python3 -m compileall /home/user/vibetrader/bot /home/user/vibetrader/data/fetch_ohlcv.py
- reviewed runtime wiring and README operating instructions

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/luaroncrew/vibetrader/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->